### PR TITLE
Put window back on screen

### DIFF
--- a/AirScout/MapDlg.cs
+++ b/AirScout/MapDlg.cs
@@ -1694,6 +1694,19 @@ namespace AirScout
             }
         }
 
+        private bool IsVisibleOnAnyScreen(Rectangle rect)
+        {
+            foreach (Screen screen in Screen.AllScreens)
+            {
+                if (screen.WorkingArea.IntersectsWith(rect))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         private void MapDlg_Load(object sender, EventArgs e)
         {
             try
@@ -2021,8 +2034,23 @@ namespace AirScout
             {
                 if (!SupportFunctions.IsMono)
                 {
-                    this.Size = Properties.Settings.Default.General_WindowSize;
-                    this.Location = Properties.Settings.Default.General_WindowLocation;
+                    // Set window location and size
+                    if (Settings.Default.General_WindowLocation != null &&
+                        Settings.Default.General_WindowSize != null &&
+                        IsVisibleOnAnyScreen(new Rectangle(Settings.Default.General_WindowLocation, Settings.Default.General_WindowSize)))
+                    {
+                        Location = Settings.Default.General_WindowLocation;
+                        Size = Settings.Default.General_WindowSize;
+                    }
+                    else
+                    {
+                        if (Settings.Default.General_WindowSize != null &&
+                            Settings.Default.General_WindowSize != System.Drawing.Size.Empty)
+                            Size = Settings.Default.General_WindowSize;
+                        StartPosition = FormStartPosition.Manual;
+                        Location = new System.Drawing.Point(Screen.PrimaryScreen.WorkingArea.Width - this.Width,
+                                             Screen.PrimaryScreen.WorkingArea.Height - this.Height);
+                    }
                     this.WindowState = Properties.Settings.Default.General_WindowState;
                 }
                 else
@@ -3438,9 +3466,11 @@ namespace AirScout
                     // restore window size, state and location
                     try
                     {
+                        if (IsVisibleOnAnyScreen(new Rectangle(Properties.Settings.Default.General_WindowLocation, Properties.Settings.Default.General_WindowSize))) { 
                         this.WindowState = Properties.Settings.Default.General_WindowState;
                         this.Size = Properties.Settings.Default.General_WindowSize;
                         this.Location = Properties.Settings.Default.General_WindowLocation;
+                    }
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
If the old window position is on a screen which is no longer attached or if the screen configuration has changed make sure that the window is placed back into the visible area.

If the window would not be visible again, move it back to the primary screen.

Code has been taken from wtKST, thanks Alex 